### PR TITLE
feat: 管理者権限チェックの多層防御を強化

### DIFF
--- a/admin/views/page-main.php
+++ b/admin/views/page-main.php
@@ -14,6 +14,10 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( '権限がありません。', 'htaccess-ss' ) );
+}
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( '.htaccess セキュリティ設定', 'htaccess-ss' ); ?></h1>

--- a/htaccess-security-settings.php
+++ b/htaccess-security-settings.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Htaccess Security Settings
  * Description: WordPress のセキュリティを強化するために .htaccess ファイルに設定を追加するプラグインです。
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Rocket Martue
  * Plugin URI: https://github.com/rocket-martue/htaccess-security-settings
  * License: GPL-2.0-or-later
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'HSS_VERSION', '1.3.0' );
+define( 'HSS_VERSION', '1.3.1' );
 define( 'HSS_PLUGIN_FILE', __FILE__ );
 define( 'HSS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HSS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/class-hss-admin-page.php
+++ b/includes/class-hss-admin-page.php
@@ -115,6 +115,10 @@ class HSS_Admin_Page {
 			return;
 		}
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$action = sanitize_key( wp_unslash( $_POST['htaccess_ss_action'] ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rocketmartue
 Tags: htaccess, security, headers, csp, performance
 Requires at least: 6.0
 Tested up to: 6.8
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -95,6 +95,11 @@ WordPress の管理画面から .htaccess のセキュリティ設定を GUI で
 いいえ。このプラグインは Apache の `.htaccess` に特化しています。Nginx や LiteSpeed 等では動作しません。
 
 == Changelog ==
+
+= 1.3.1 =
+* `handle_form_submission()` の入口に早期権限チェックを追加（多層防御の強化）
+* ビューテンプレート `page-main.php` にフェイルセーフとして権限チェックを追加
+* 権限チェックのユニットテスト（AdminPageTest）を追加
 
 = 1.3.0 =
 * プリセット機能を追加（おすすめ設定・セキュリティヘッダーのみ・パフォーマンス重視・最大セキュリティ）

--- a/tests/Unit/AdminPageTest.php
+++ b/tests/Unit/AdminPageTest.php
@@ -31,6 +31,11 @@ class AdminPageTest extends WP_UnitTestCase {
 		parent::set_up();
 		$this->settings   = new HSS_Settings();
 		$this->admin_page = new HSS_Admin_Page( $this->settings );
+
+		delete_option( HSS_Settings::OPTION_KEY );
+		delete_option( HSS_Settings::BACKUP_ROOT_KEY );
+		delete_option( HSS_Settings::BACKUP_ADMIN_KEY );
+		delete_option( HSS_Settings::BACKUP_TIME_KEY );
 	}
 
 	/**
@@ -45,6 +50,7 @@ class AdminPageTest extends WP_UnitTestCase {
 			$_POST['htaccess_ss_delete_all_nonce'],
 			$_POST['preset_key'],
 			$_POST['_tab'],
+			$_REQUEST['nonce'],
 			$_REQUEST['_ajax_nonce']
 		);
 		parent::tear_down();

--- a/tests/Unit/AdminPageTest.php
+++ b/tests/Unit/AdminPageTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * HSS_Admin_Page の権限チェックテスト
+ *
+ * @package HtaccessSS
+ */
+
+/**
+ * 管理画面クラスの権限チェックテスト
+ */
+class AdminPageTest extends WP_UnitTestCase {
+
+	/**
+	 * テスト対象のインスタンス
+	 *
+	 * @var HSS_Admin_Page
+	 */
+	private $admin_page;
+
+	/**
+	 * Settings インスタンス
+	 *
+	 * @var HSS_Settings
+	 */
+	private $settings;
+
+	/**
+	 * テスト前のセットアップ
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->settings   = new HSS_Settings();
+		$this->admin_page = new HSS_Admin_Page( $this->settings );
+	}
+
+	// =========================================================================
+	// add_menu_page — manage_options 権限
+	// =========================================================================
+
+	/**
+	 * add_options_page() に manage_options が渡されていることを検証
+	 */
+	public function test_menu_page_requires_manage_options() {
+		// 管理者としてログイン
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		set_current_screen( 'dashboard' );
+		$this->admin_page->add_menu_page();
+
+		$menu_slug = 'htaccess-security-settings';
+		$page_hook = get_plugin_page_hookname( $menu_slug, 'options-general.php' );
+
+		$this->assertNotEmpty( $page_hook, 'メニューページが登録されているべき' );
+	}
+
+	// =========================================================================
+	// render_page — 権限なしで早期 return
+	// =========================================================================
+
+	/**
+	 * 権限なしユーザーで render_page() が HTML を出力しないことを検証
+	 */
+	public function test_render_page_returns_early_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		ob_start();
+		$this->admin_page->render_page();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, '権限なしユーザーでは出力なしであるべき' );
+	}
+
+	// =========================================================================
+	// handle_form_submission — 権限なしで早期 return
+	// =========================================================================
+
+	/**
+	 * 権限なしユーザーで handle_form_submission() がアクション未実行
+	 */
+	public function test_handle_form_submission_returns_early_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['htaccess_ss_action'] = 'save';
+
+		// 権限なしなのでリダイレクト（exit）せず return するはず
+		$this->admin_page->handle_form_submission();
+
+		// ここに到達できれば、早期 return されている
+		$this->assertTrue( true, 'handle_form_submission() が早期 return した' );
+
+		unset( $_POST['htaccess_ss_action'] );
+	}
+
+	// =========================================================================
+	// handle_save — 権限なしで wp_die
+	// =========================================================================
+
+	/**
+	 * 権限なしで handle_save() が wp_die する
+	 */
+	public function test_handle_save_dies_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['htaccess_ss_action'] = 'save';
+		$_POST['htaccess_ss_nonce']  = wp_create_nonce( 'htaccess_ss_save' );
+
+		// handle_form_submission の入口で弾かれるため wp_die に到達しない
+		$this->admin_page->handle_form_submission();
+		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
+
+		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_nonce'] );
+	}
+
+	// =========================================================================
+	// handle_restore — 権限なしで wp_die
+	// =========================================================================
+
+	/**
+	 * 権限なしで handle_restore() が呼ばれない
+	 */
+	public function test_handle_restore_dies_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['htaccess_ss_action']        = 'restore';
+		$_POST['htaccess_ss_restore_nonce'] = wp_create_nonce( 'htaccess_ss_restore' );
+
+		$this->admin_page->handle_form_submission();
+		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
+
+		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_restore_nonce'] );
+	}
+
+	// =========================================================================
+	// handle_apply_preset — 権限なしで wp_die
+	// =========================================================================
+
+	/**
+	 * 権限なしで handle_apply_preset() が呼ばれない
+	 */
+	public function test_handle_apply_preset_dies_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['htaccess_ss_action']       = 'apply_preset';
+		$_POST['htaccess_ss_preset_nonce'] = wp_create_nonce( 'htaccess_ss_preset' );
+		$_POST['preset_key']               = 'recommended';
+
+		$this->admin_page->handle_form_submission();
+		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
+
+		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_preset_nonce'], $_POST['preset_key'] );
+	}
+
+	// =========================================================================
+	// handle_delete_all — 権限なしで wp_die
+	// =========================================================================
+
+	/**
+	 * 権限なしで handle_delete_all() が呼ばれない
+	 */
+	public function test_handle_delete_all_dies_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['htaccess_ss_action']           = 'delete_all';
+		$_POST['htaccess_ss_delete_all_nonce'] = wp_create_nonce( 'htaccess_ss_delete_all' );
+
+		$this->admin_page->handle_form_submission();
+		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
+
+		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_delete_all_nonce'] );
+	}
+
+	// =========================================================================
+	// ajax_download — 権限なしで拒否
+	// =========================================================================
+
+	/**
+	 * 権限なしユーザーで ajax_download() が wp_die する
+	 */
+	public function test_ajax_download_dies_without_capability() {
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		// check_ajax_referer が失敗するので WPDieException が発生する
+		$this->expectException( 'WPDieException' );
+
+		$this->admin_page->ajax_download();
+	}
+
+	// =========================================================================
+	// 管理者では正常動作
+	// =========================================================================
+
+	/**
+	 * 管理者で render_page() が HTML を出力することを検証
+	 */
+	public function test_render_page_outputs_html_for_admin() {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+
+		ob_start();
+		$this->admin_page->render_page();
+		$output = ob_get_clean();
+
+		$this->assertNotEmpty( $output, '管理者は設定ページを表示できるべき' );
+		$this->assertStringContainsString( '.htaccess', $output );
+	}
+}

--- a/tests/Unit/AdminPageTest.php
+++ b/tests/Unit/AdminPageTest.php
@@ -33,6 +33,23 @@ class AdminPageTest extends WP_UnitTestCase {
 		$this->admin_page = new HSS_Admin_Page( $this->settings );
 	}
 
+	/**
+	 * テスト後のクリーンアップ
+	 */
+	public function tear_down(): void {
+		unset(
+			$_POST['htaccess_ss_action'],
+			$_POST['htaccess_ss_nonce'],
+			$_POST['htaccess_ss_restore_nonce'],
+			$_POST['htaccess_ss_preset_nonce'],
+			$_POST['htaccess_ss_delete_all_nonce'],
+			$_POST['preset_key'],
+			$_POST['_tab'],
+			$_REQUEST['_ajax_nonce']
+		);
+		parent::tear_down();
+	}
+
 	// =========================================================================
 	// add_menu_page — manage_options 権限
 	// =========================================================================
@@ -41,17 +58,25 @@ class AdminPageTest extends WP_UnitTestCase {
 	 * add_options_page() に manage_options が渡されていることを検証
 	 */
 	public function test_menu_page_requires_manage_options() {
-		// 管理者としてログイン
+		global $submenu;
+
 		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin );
 
 		set_current_screen( 'dashboard' );
 		$this->admin_page->add_menu_page();
 
-		$menu_slug = 'htaccess-security-settings';
-		$page_hook = get_plugin_page_hookname( $menu_slug, 'options-general.php' );
+		$found_capability = '';
+		if ( isset( $submenu['options-general.php'] ) ) {
+			foreach ( $submenu['options-general.php'] as $item ) {
+				if ( 'htaccess-security-settings' === $item[2] ) {
+					$found_capability = $item[1];
+					break;
+				}
+			}
+		}
 
-		$this->assertNotEmpty( $page_hook, 'メニューページが登録されているべき' );
+		$this->assertSame( 'manage_options', $found_capability, 'メニューの権限が manage_options であるべき' );
 	}
 
 	// =========================================================================
@@ -73,56 +98,36 @@ class AdminPageTest extends WP_UnitTestCase {
 	}
 
 	// =========================================================================
-	// handle_form_submission — 権限なしで早期 return
+	// handle_form_submission — 権限なしで設定が変更されない
 	// =========================================================================
 
 	/**
-	 * 権限なしユーザーで handle_form_submission() がアクション未実行
+	 * 権限なしユーザーで save アクションを送信しても設定が変更されない
 	 */
-	public function test_handle_form_submission_returns_early_without_capability() {
+	public function test_handle_form_submission_save_does_not_change_settings_without_capability() {
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
-		$_POST['htaccess_ss_action'] = 'save';
-
-		// 権限なしなのでリダイレクト（exit）せず return するはず
-		$this->admin_page->handle_form_submission();
-
-		// ここに到達できれば、早期 return されている
-		$this->assertTrue( true, 'handle_form_submission() が早期 return した' );
-
-		unset( $_POST['htaccess_ss_action'] );
-	}
-
-	// =========================================================================
-	// handle_save — 権限なしで wp_die
-	// =========================================================================
-
-	/**
-	 * 権限なしで handle_save() が wp_die する
-	 */
-	public function test_handle_save_dies_without_capability() {
-		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
-		wp_set_current_user( $editor );
+		$before = get_option( HSS_Settings::OPTION_KEY );
 
 		$_POST['htaccess_ss_action'] = 'save';
 		$_POST['htaccess_ss_nonce']  = wp_create_nonce( 'htaccess_ss_save' );
+		$_POST['_tab']               = 'options';
 
-		// handle_form_submission の入口で弾かれるため wp_die に到達しない
 		$this->admin_page->handle_form_submission();
-		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
 
-		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_nonce'] );
+		$after = get_option( HSS_Settings::OPTION_KEY );
+		$this->assertSame( $before, $after, '権限なしでは設定が変更されないべき' );
 	}
 
-	// =========================================================================
-	// handle_restore — 権限なしで wp_die
-	// =========================================================================
-
 	/**
-	 * 権限なしで handle_restore() が呼ばれない
+	 * 権限なしユーザーで restore アクションを送信してもバックアップが復元されない
 	 */
-	public function test_handle_restore_dies_without_capability() {
+	public function test_handle_form_submission_restore_does_not_restore_without_capability() {
+		// ダミーのバックアップデータを設置
+		update_option( HSS_Settings::BACKUP_ROOT_KEY, 'dummy backup data' );
+		$backup_before = get_option( HSS_Settings::BACKUP_ROOT_KEY );
+
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
@@ -130,40 +135,38 @@ class AdminPageTest extends WP_UnitTestCase {
 		$_POST['htaccess_ss_restore_nonce'] = wp_create_nonce( 'htaccess_ss_restore' );
 
 		$this->admin_page->handle_form_submission();
-		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
 
-		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_restore_nonce'] );
+		$backup_after = get_option( HSS_Settings::BACKUP_ROOT_KEY );
+		$this->assertSame( $backup_before, $backup_after, '権限なしではバックアップが消費されないべき' );
 	}
 
-	// =========================================================================
-	// handle_apply_preset — 権限なしで wp_die
-	// =========================================================================
-
 	/**
-	 * 権限なしで handle_apply_preset() が呼ばれない
+	 * 権限なしユーザーで apply_preset アクションを送信しても設定が変更されない
 	 */
-	public function test_handle_apply_preset_dies_without_capability() {
+	public function test_handle_form_submission_preset_does_not_apply_without_capability() {
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
+
+		$before = get_option( HSS_Settings::OPTION_KEY );
 
 		$_POST['htaccess_ss_action']       = 'apply_preset';
 		$_POST['htaccess_ss_preset_nonce'] = wp_create_nonce( 'htaccess_ss_preset' );
 		$_POST['preset_key']               = 'recommended';
 
 		$this->admin_page->handle_form_submission();
-		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
 
-		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_preset_nonce'], $_POST['preset_key'] );
+		$after = get_option( HSS_Settings::OPTION_KEY );
+		$this->assertSame( $before, $after, '権限なしではプリセットが適用されないべき' );
 	}
 
-	// =========================================================================
-	// handle_delete_all — 権限なしで wp_die
-	// =========================================================================
-
 	/**
-	 * 権限なしで handle_delete_all() が呼ばれない
+	 * 権限なしユーザーで delete_all アクションを送信しても設定が削除されない
 	 */
-	public function test_handle_delete_all_dies_without_capability() {
+	public function test_handle_form_submission_delete_all_does_not_delete_without_capability() {
+		// 事前にオプションを設定
+		update_option( HSS_Settings::OPTION_KEY, array( 'test' => true ) );
+		update_option( HSS_Settings::BACKUP_TIME_KEY, '2026-01-01 00:00:00' );
+
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
@@ -171,9 +174,9 @@ class AdminPageTest extends WP_UnitTestCase {
 		$_POST['htaccess_ss_delete_all_nonce'] = wp_create_nonce( 'htaccess_ss_delete_all' );
 
 		$this->admin_page->handle_form_submission();
-		$this->assertTrue( true, '入口の権限チェックで弾かれた' );
 
-		unset( $_POST['htaccess_ss_action'], $_POST['htaccess_ss_delete_all_nonce'] );
+		$this->assertNotFalse( get_option( HSS_Settings::OPTION_KEY ), '権限なしでは設定が削除されないべき' );
+		$this->assertNotFalse( get_option( HSS_Settings::BACKUP_TIME_KEY ), '権限なしではバックアップ日時が削除されないべき' );
 	}
 
 	// =========================================================================
@@ -181,13 +184,17 @@ class AdminPageTest extends WP_UnitTestCase {
 	// =========================================================================
 
 	/**
-	 * 権限なしユーザーで ajax_download() が wp_die する
+	 * 権限なしユーザーで ajax_download() が wp_die する（有効な nonce あり）
 	 */
 	public function test_ajax_download_dies_without_capability() {
 		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor );
 
-		// check_ajax_referer が失敗するので WPDieException が発生する
+		// 有効な nonce を設定して権限チェックに到達させる
+		$nonce                   = wp_create_nonce( 'htaccess_ss_download' );
+		$_REQUEST['nonce']       = $nonce; // phpcs:ignore WordPress.Security
+		$_REQUEST['_ajax_nonce'] = $nonce;
+
 		$this->expectException( 'WPDieException' );
 
 		$this->admin_page->ajax_download();


### PR DESCRIPTION
## 概要

Closes #8

設定画面（表示・操作・AJAX）の管理者権限チェックに多層防御（Defense in Depth）を追加し、不正アクセスや権限昇格を防止する。

## 変更内容

### Task 1: `handle_form_submission()` に早期権限チェックを追加

- `handle_form_submission()` の入口で `current_user_can('manage_options')` チェックを追加
- 各個別ハンドラに到達する前に権限なしユーザーを弾く

### Task 2: ビューテンプレートに権限チェックを追加

- `admin/views/page-main.php` の ABSPATH チェック直後にフェイルセーフとして `current_user_can('manage_options')` を追加
- 万が一テンプレートが直接 include された場合の防御層

### Task 3: 権限チェックのユニットテストを追加

`tests/Unit/AdminPageTest.php` に以下 8 ケースを新規作成：

| # | テスト | 内容 |
|---|---|---|
| 1 | `test_menu_page_requires_manage_options` | `$submenu` から `manage_options` 権限を直接アサート |
| 2 | `test_render_page_returns_early_without_capability` | 権限なしで出力なしを検証 |
| 3 | `test_handle_form_submission_save_does_not_change_settings_without_capability` | 権限なしで設定が変更されないことを検証 |
| 4 | `test_handle_form_submission_restore_does_not_restore_without_capability` | 権限なしでバックアップが消費されないことを検証 |
| 5 | `test_handle_form_submission_preset_does_not_apply_without_capability` | 権限なしでプリセットが適用されないことを検証 |
| 6 | `test_handle_form_submission_delete_all_does_not_delete_without_capability` | 権限なしでオプションが削除されないことを検証 |
| 7 | `test_ajax_download_dies_without_capability` | 有効な nonce 付きで AJAX 権限拒否を検証 |
| 8 | `test_render_page_outputs_html_for_admin` | 管理者では正常出力を検証 |

### バージョン更新

- `1.3.0` → `1.3.1`（メインファイル・readme.txt）

## 検証方法

1. `composer phpcs` — エラーなし ✅
2. `composer phpunit` — CI で確認
3. 管理者：全機能が正常動作すること
4. 編集者：メニュー非表示、直接 URL でも権限エラー