### PR TITLE
セキュリティ監査レポートの改善推奨項目に対応（深刻度: 低 × 3件）

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,25 @@ htaccess-security-settings/
 │       ├── tab-rewrite.php
 │       ├── tab-headers.php
 │       ├── tab-cache.php
-│       ├── tab-wp-admin.php
-│       └── partial-preview.php
+│       └── tab-wp-admin.php
+├── tests/
+│   ├── bootstrap.php
+│   └── Unit/
+│       ├── AdminPageTest.php
+│       ├── HtaccessBuilderTest.php
+│       ├── HtaccessWriterTest.php
+│       └── SettingsTest.php
+├── bin/
+│   └── install-wp-tests.sh           # テスト環境セットアップ
+├── .github/
+│   └── workflows/                    # CI（phpcs / phpunit / PHP互換性 / JS lint / ZIP ビルド）
+├── blueprint.json                    # WordPress Playground 設定
 ├── composer.json
-└── phpcs.xml
+├── package.json
+├── phpcs.xml
+├── phpunit.xml.dist
+├── readme.txt                        # WordPress.org 用 readme
+└── .wp-env.json                      # wp-env 開発環境設定
 ```
 
 ## 開発
@@ -127,10 +142,24 @@ composer phpcs
 composer phpcbf
 ```
 
-## デフォルト設定で生成される .htaccess
+## プリセット
 
-プラグインを有効化し、初期設定のまま保存した場合に `.htaccess` へ書き込まれるブロックです。  
-IP ブロック・HTTPS リダイレクト・wp-admin Basic 認証はデフォルト OFF のため含まれません。
+設定画面からワンクリックで適用できる 4 種類のプリセットを用意しています。
+
+| プリセット | 説明 |
+|---|---|
+| **おすすめ設定** | セキュリティとパフォーマンスのバランスが取れた推奨構成 |
+| **セキュリティヘッダーのみ** | セキュリティヘッダーだけを有効にし、他の設定はすべて無効化 |
+| **パフォーマンス重視** | キャッシュ・圧縮設定のみ有効化 |
+| **最大セキュリティ** | Basic 認証を除くすべてのセキュリティ項目を有効化 |
+
+> [!TIP]
+> 初期状態ではすべての設定が OFF です。まずは「おすすめ設定」プリセットを適用するのがおすすめです。
+
+## 「おすすめ設定」プリセットで生成される .htaccess
+
+「おすすめ設定」プリセットを適用した場合に `.htaccess` へ書き込まれるブロックです。  
+IP ブロック・不正クエリ文字列ブロック・wp-admin Basic 認証はプリセットに含まれないため出力されません。
 
 ```apache
 # BEGIN Htaccess Security Settings
@@ -212,6 +241,11 @@ ErrorDocument 404 default
 	RewriteCond %{REQUEST_URI} ^/wp-includes/ [NC]
 	RewriteCond %{REQUEST_FILENAME} -d
 	RewriteRule .* - [F,L]
+
+	# HTTPSリダイレクト
+	RewriteCond %{HTTPS} !=on [NC]
+	RewriteCond %{HTTP:X-Forwarded-Proto} !https [NC]
+	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 </IfModule>
 

--- a/admin/views/tab-headers.php
+++ b/admin/views/tab-headers.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'HSTS を有効にする', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'ブラウザに「今後必ずHTTPSで接続する」よう指示し、中間者攻撃を防ぎます。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-hsts-options htaccess-ss-sub-options" <?php echo $tab_settings['hsts_enabled'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-hsts-options htaccess-ss-sub-options" <?php echo $tab_settings['hsts_enabled'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<label for="htaccess-ss-hsts-max-age"><?php esc_html_e( 'max-age（秒）', 'htaccess-ss' ); ?></label>
 				<input type="number" id="htaccess-ss-hsts-max-age" name="htaccess_ss_settings[hsts_max_age]" value="<?php echo esc_attr( $tab_settings['hsts_max_age'] ); ?>" min="0" max="126144000" class="small-text" />
 				<span class="description"><?php esc_html_e( '推奨: 63072000（2年）', 'htaccess-ss' ); ?></span>
@@ -54,7 +54,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tr>
 </table>
 
-<div class="htaccess-ss-csp-options htaccess-ss-sub-options" <?php echo $tab_settings['csp_enabled'] ? '' : 'style="display:none;"'; ?>>
+<div class="htaccess-ss-csp-options htaccess-ss-sub-options" <?php echo $tab_settings['csp_enabled'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 	<table class="form-table" role="presentation">
 		<tr>
 			<th scope="row"><?php esc_html_e( 'CSP モード', 'htaccess-ss' ); ?></th>
@@ -73,7 +73,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</fieldset>
 			</td>
 		</tr>
-		<tr class="htaccess-ss-csp-upgrade-row" <?php echo 'enforce' === $tab_settings['csp_mode'] ? '' : 'style="display:none;"'; ?>>
+		<tr class="htaccess-ss-csp-upgrade-row" <?php echo 'enforce' === $tab_settings['csp_mode'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 			<th scope="row"><?php esc_html_e( 'upgrade-insecure-requests', 'htaccess-ss' ); ?></th>
 			<td>
 				<label>
@@ -218,7 +218,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tr>
 </table>
 
-<div class="htaccess-ss-perm-options htaccess-ss-sub-options" <?php echo $tab_settings['permissions_enabled'] ? '' : 'style="display:none;"'; ?>>
+<div class="htaccess-ss-perm-options htaccess-ss-sub-options" <?php echo $tab_settings['permissions_enabled'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 	<table class="form-table" role="presentation">
 		<tr>
 			<th scope="row"><?php esc_html_e( '無効にする API', 'htaccess-ss' ); ?></th>

--- a/admin/views/tab-ip-block.php
+++ b/admin/views/tab-ip-block.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'IP ブロックを有効にする', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( '指定したIPアドレスからのアクセスを 403 Forbidden で拒否します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-ip-options htaccess-ss-sub-options" <?php echo $tab_settings['enabled'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-ip-options htaccess-ss-sub-options" <?php echo $tab_settings['enabled'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<table class="form-table form-table-inner" role="presentation">
 					<tr>
 						<th scope="row">

--- a/admin/views/tab-options.php
+++ b/admin/views/tab-options.php
@@ -78,7 +78,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'wp-login.php にBasic認証を追加する', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'ログインページの前にID/パスワード認証を追加し、ブルートフォース攻撃を防ぎます。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-login-options htaccess-ss-sub-options" <?php echo $tab_settings['wp_login_basic_auth'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-login-options htaccess-ss-sub-options" <?php echo $tab_settings['wp_login_basic_auth'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<label for="htaccess-ss-htpasswd-path"><?php esc_html_e( '.htpasswd ファイルの絶対パス', 'htaccess-ss' ); ?></label>
 				<input type="text" id="htaccess-ss-htpasswd-path" name="htaccess_ss_settings[htpasswd_path]" value="<?php echo esc_attr( $tab_settings['htpasswd_path'] ); ?>" class="regular-text" placeholder="/home/user/domain/htpasswd/wp-admin/.htpasswd" />
 			</div>

--- a/admin/views/tab-rewrite.php
+++ b/admin/views/tab-rewrite.php
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( '悪意のあるボット・スクリプトをブロック', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'User-Agentに特定の文字列が含まれるリクエストを403で拒否します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-bot-options htaccess-ss-sub-options" <?php echo $tab_settings['block_bad_bots'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-bot-options htaccess-ss-sub-options" <?php echo $tab_settings['block_bad_bots'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<label for="htaccess-ss-bad-bot-list"><?php esc_html_e( 'ブロック対象 User-Agent（1行に1つ）', 'htaccess-ss' ); ?></label>
 				<textarea id="htaccess-ss-bad-bot-list" name="htaccess_ss_settings[bad_bot_list]" rows="6" class="large-text code"><?php echo esc_textarea( $tab_settings['bad_bot_list'] ); ?></textarea>
 				<p class="description"><?php esc_html_e( '※ curl, python など正規のAPIクライアントが使う場合もあるので注意してください。', 'htaccess-ss' ); ?></p>
@@ -45,7 +45,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'バックドア/マルウェア探索をブロック', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( '既知のバックドアファイル名へのアクセスを403で拒否します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-backdoor-options htaccess-ss-sub-options" <?php echo $tab_settings['block_backdoors'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-backdoor-options htaccess-ss-sub-options" <?php echo $tab_settings['block_backdoors'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<label for="htaccess-ss-backdoor-list"><?php esc_html_e( 'ブロック対象ファイル名（1行に1つ）', 'htaccess-ss' ); ?></label>
 				<textarea id="htaccess-ss-backdoor-list" name="htaccess_ss_settings[backdoor_list]" rows="6" class="large-text code"><?php echo esc_textarea( $tab_settings['backdoor_list'] ); ?></textarea>
 			</div>
@@ -94,7 +94,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( '不正なクエリ文字列をブロック', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( '指定したパラメータ名を含むリクエストに 410 Gone を返します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-bad-query-options htaccess-ss-sub-options" <?php echo $tab_settings['block_bad_query'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-bad-query-options htaccess-ss-sub-options" <?php echo $tab_settings['block_bad_query'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<label for="htaccess-ss-bad-query-list"><?php esc_html_e( 'ブロック対象パラメータ名（1行に1つ）', 'htaccess-ss' ); ?></label>
 				<textarea id="htaccess-ss-bad-query-list" name="htaccess_ss_settings[bad_query_list]" rows="4" class="large-text code"><?php echo esc_textarea( $tab_settings['bad_query_list'] ); ?></textarea>
 				<p class="description"><?php esc_html_e( '例: w と入力すると ?w=xxx のクエリをブロックします。', 'htaccess-ss' ); ?></p>

--- a/admin/views/tab-wp-admin.php
+++ b/admin/views/tab-wp-admin.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'wp-admin に Basic 認証をかける', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( '管理画面へのアクセスにユーザー名・パスワードを要求します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-sub-options" <?php echo $tab_settings['basic_auth'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-sub-options" <?php echo $tab_settings['basic_auth'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<table class="form-table" role="presentation">
 					<tr>
 						<th scope="row">
@@ -53,7 +53,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php esc_html_e( 'upgrade.php へのアクセスをサーバーIPのみに制限する', 'htaccess-ss' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'WordPress の自動更新に必要な upgrade.php をサーバー自身のIPからのみ許可します。', 'htaccess-ss' ); ?></p>
-			<div class="htaccess-ss-sub-options" <?php echo $tab_settings['upgrade_ip_exclude'] ? '' : 'style="display:none;"'; ?>>
+			<div class="htaccess-ss-sub-options" <?php echo $tab_settings['upgrade_ip_exclude'] ? '' : 'style="' . esc_attr( 'display:none;' ) . '"'; ?>>
 				<table class="form-table" role="presentation">
 					<tr>
 						<th scope="row">

--- a/includes/class-hss-htaccess-builder.php
+++ b/includes/class-hss-htaccess-builder.php
@@ -74,8 +74,14 @@ class HSS_Htaccess_Builder {
 			return array();
 		}
 
+		$htpasswd_path = sanitize_text_field( $admin['htpasswd_path'] );
+		$real_path     = realpath( $htpasswd_path );
+		if ( ! $real_path || ! file_exists( $real_path ) || is_dir( $real_path ) ) {
+			return array();
+		}
+
 		$lines   = array();
-		$lines[] = 'AuthUserFile "' . $admin['htpasswd_path'] . '"';
+		$lines[] = 'AuthUserFile "' . $real_path . '"';
 		$lines[] = 'AuthName "Member Site"';
 		$lines[] = 'AuthType BASIC';
 		$lines[] = 'require valid-user';
@@ -165,14 +171,18 @@ class HSS_Htaccess_Builder {
 
 		// wp-login.php Basic 認証
 		if ( $options['wp_login_basic_auth'] && ! empty( $options['htpasswd_path'] ) ) {
-			$lines[] = '# wp-login.php を保護';
-			$lines[] = '<Files wp-login.php>';
-			$lines[] = "\t" . 'AuthUserFile "' . $options['htpasswd_path'] . '"';
-			$lines[] = "\t" . 'AuthName "Member Site"';
-			$lines[] = "\t" . 'AuthType BASIC';
-			$lines[] = "\t" . 'require valid-user';
-			$lines[] = '</Files>';
-			$lines[] = '';
+			$htpasswd_path = sanitize_text_field( $options['htpasswd_path'] );
+			$real_path     = realpath( $htpasswd_path );
+			if ( $real_path && file_exists( $real_path ) && ! is_dir( $real_path ) ) {
+				$lines[] = '# wp-login.php を保護';
+				$lines[] = '<Files wp-login.php>';
+				$lines[] = "\t" . 'AuthUserFile "' . $real_path . '"';
+				$lines[] = "\t" . 'AuthName "Member Site"';
+				$lines[] = "\t" . 'AuthType BASIC';
+				$lines[] = "\t" . 'require valid-user';
+				$lines[] = '</Files>';
+				$lines[] = '';
+			}
 		}
 
 		// .htaccess 保護

--- a/includes/class-hss-htaccess-builder.php
+++ b/includes/class-hss-htaccess-builder.php
@@ -15,6 +15,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 class HSS_Htaccess_Builder {
 
 	/**
+	 * Htpasswd パスをサニタイズ・検証し、実パスを返す
+	 *
+	 * @param string $path 入力パス
+	 * @return string|false 検証済み実パス。無効なら false
+	 */
+	private function resolve_htpasswd_path( $path ) {
+		$sanitized = sanitize_text_field( $path );
+		$real_path = realpath( $sanitized );
+		if ( ! $real_path || ! file_exists( $real_path ) || is_dir( $real_path ) ) {
+			return false;
+		}
+		return $real_path;
+	}
+
+	/**
 	 * ルート .htaccess のディレクティブを生成する
 	 *
 	 * @param array $settings 全設定配列
@@ -74,9 +89,8 @@ class HSS_Htaccess_Builder {
 			return array();
 		}
 
-		$htpasswd_path = sanitize_text_field( $admin['htpasswd_path'] );
-		$real_path     = realpath( $htpasswd_path );
-		if ( ! $real_path || ! file_exists( $real_path ) || is_dir( $real_path ) ) {
+		$real_path = $this->resolve_htpasswd_path( $admin['htpasswd_path'] );
+		if ( ! $real_path ) {
 			return array();
 		}
 
@@ -171,9 +185,8 @@ class HSS_Htaccess_Builder {
 
 		// wp-login.php Basic 認証
 		if ( $options['wp_login_basic_auth'] && ! empty( $options['htpasswd_path'] ) ) {
-			$htpasswd_path = sanitize_text_field( $options['htpasswd_path'] );
-			$real_path     = realpath( $htpasswd_path );
-			if ( $real_path && file_exists( $real_path ) && ! is_dir( $real_path ) ) {
+			$real_path = $this->resolve_htpasswd_path( $options['htpasswd_path'] );
+			if ( $real_path ) {
 				$lines[] = '# wp-login.php を保護';
 				$lines[] = '<Files wp-login.php>';
 				$lines[] = "\t" . 'AuthUserFile "' . $real_path . '"';

--- a/includes/class-hss-htaccess-builder.php
+++ b/includes/class-hss-htaccess-builder.php
@@ -15,14 +15,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class HSS_Htaccess_Builder {
 
 	/**
-	 * Htpasswd パスをサニタイズ・検証し、実パスを返す
+	 * Htpasswd パスを検証し、実パスを返す
+	 *
+	 * 設定保存時に sanitize_text_field() 済みのため、ここでは realpath() による
+	 * パス解決と存在チェックのみ行う。
 	 *
 	 * @param string $path 入力パス
 	 * @return string|false 検証済み実パス。無効なら false
 	 */
 	private function resolve_htpasswd_path( $path ) {
-		$sanitized = sanitize_text_field( $path );
-		$real_path = realpath( $sanitized );
+		if ( ! is_string( $path ) ) {
+			return false;
+		}
+		$real_path = realpath( trim( $path ) );
 		if ( ! $real_path || ! file_exists( $real_path ) || is_dir( $real_path ) ) {
 			return false;
 		}

--- a/includes/class-hss-htaccess-builder.php
+++ b/includes/class-hss-htaccess-builder.php
@@ -28,7 +28,7 @@ class HSS_Htaccess_Builder {
 			return false;
 		}
 		$real_path = realpath( trim( $path ) );
-		if ( ! $real_path || ! file_exists( $real_path ) || is_dir( $real_path ) ) {
+		if ( ! $real_path || ! is_file( $real_path ) || ! is_readable( $real_path ) ) {
 			return false;
 		}
 		return $real_path;

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,8 @@ WordPress の管理画面から .htaccess のセキュリティ設定を GUI で
 * `handle_form_submission()` の入口に早期権限チェックを追加（多層防御の強化）
 * ビューテンプレート `page-main.php` にフェイルセーフとして権限チェックを追加
 * 権限チェックのユニットテスト（AdminPageTest）を追加
+* ビューファイルの `style` 属性出力を `esc_attr()` でエスケープ
+* `htpasswd_path` に `realpath()` / `file_exists()` / `is_dir()` のバリデーションを追加
 
 = 1.3.0 =
 * プリセット機能を追加（おすすめ設定・セキュリティヘッダーのみ・パフォーマンス重視・最大セキュリティ）

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ WordPress の管理画面から .htaccess のセキュリティ設定を GUI で
 * ビューテンプレート `page-main.php` にフェイルセーフとして権限チェックを追加
 * 権限チェックのユニットテスト（AdminPageTest）を追加
 * ビューファイルの `style` 属性出力を `esc_attr()` でエスケープ
-* `htpasswd_path` に `realpath()` / `file_exists()` / `is_dir()` のバリデーションを追加
+* `htpasswd_path` に `realpath()` / `is_file()` / `is_readable()` のバリデーションを追加
 
 = 1.3.0 =
 * プリセット機能を追加（おすすめ設定・セキュリティヘッダーのみ・パフォーマンス重視・最大セキュリティ）

--- a/tests/Unit/HtaccessBuilderTest.php
+++ b/tests/Unit/HtaccessBuilderTest.php
@@ -36,7 +36,10 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 			$this->fail( 'Failed to create temporary .htpasswd file.' );
 		}
 		$this->htpasswd_path = $tmp;
-		file_put_contents( $this->htpasswd_path, 'testuser:$apr1$test$hash' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$written             = file_put_contents( $this->htpasswd_path, 'testuser:$apr1$test$hash' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === $written ) {
+			$this->fail( 'Failed to write to temporary .htpasswd file.' );
+		}
 	}
 
 	/**

--- a/tests/Unit/HtaccessBuilderTest.php
+++ b/tests/Unit/HtaccessBuilderTest.php
@@ -18,11 +18,31 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	private $builder;
 
 	/**
+	 * テスト用の一時 .htpasswd ファイルパス
+	 *
+	 * @var string
+	 */
+	private $htpasswd_path;
+
+	/**
 	 * テスト前のセットアップ
 	 */
 	public function set_up(): void {
 		parent::set_up();
 		$this->builder = new HSS_Htaccess_Builder();
+
+		$this->htpasswd_path = tempnam( sys_get_temp_dir(), 'htpasswd_test_' );
+		file_put_contents( $this->htpasswd_path, 'testuser:$apr1$test$hash' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	}
+
+	/**
+	 * テスト後のクリーンアップ
+	 */
+	public function tear_down(): void {
+		if ( file_exists( $this->htpasswd_path ) ) {
+			unlink( $this->htpasswd_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		}
+		parent::tear_down();
 	}
 
 	/**
@@ -293,12 +313,13 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_file_protection_wp_login_basic_auth() {
 		$settings                                   = $this->get_all_off_settings();
 		$settings['options']['wp_login_basic_auth'] = true;
-		$settings['options']['htpasswd_path']       = '/path/to/.htpasswd';
+		$settings['options']['htpasswd_path']       = $this->htpasswd_path;
 
 		$output = $this->build_root_string( $settings );
 
+		$expected_path = realpath( $this->htpasswd_path );
 		$this->assertStringContainsString( '<Files wp-login.php>', $output );
-		$this->assertStringContainsString( 'AuthUserFile "/path/to/.htpasswd"', $output );
+		$this->assertStringContainsString( 'AuthUserFile "' . $expected_path . '"', $output );
 		$this->assertStringContainsString( 'AuthType BASIC', $output );
 		$this->assertStringContainsString( 'require valid-user', $output );
 	}
@@ -885,12 +906,13 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_wp_admin_basic_auth() {
 		$settings                              = $this->get_all_off_settings();
 		$settings['wp_admin']['basic_auth']    = true;
-		$settings['wp_admin']['htpasswd_path'] = '/path/to/.htpasswd';
+		$settings['wp_admin']['htpasswd_path'] = $this->htpasswd_path;
 
 		$result = $this->builder->build_wp_admin( $settings );
 		$output = implode( "\n", $result );
 
-		$this->assertStringContainsString( 'AuthUserFile "/path/to/.htpasswd"', $output );
+		$expected_path = realpath( $this->htpasswd_path );
+		$this->assertStringContainsString( 'AuthUserFile "' . $expected_path . '"', $output );
 		$this->assertStringContainsString( 'AuthType BASIC', $output );
 		$this->assertStringContainsString( 'require valid-user', $output );
 	}
@@ -901,7 +923,7 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_wp_admin_ajax_exclude() {
 		$settings                              = $this->get_all_off_settings();
 		$settings['wp_admin']['basic_auth']    = true;
-		$settings['wp_admin']['htpasswd_path'] = '/path/to/.htpasswd';
+		$settings['wp_admin']['htpasswd_path'] = $this->htpasswd_path;
 		$settings['wp_admin']['ajax_exclude']  = true;
 
 		$result = $this->builder->build_wp_admin( $settings );
@@ -917,7 +939,7 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_wp_admin_upgrade_ip_exclude() {
 		$settings                                   = $this->get_all_off_settings();
 		$settings['wp_admin']['basic_auth']         = true;
-		$settings['wp_admin']['htpasswd_path']      = '/path/to/.htpasswd';
+		$settings['wp_admin']['htpasswd_path']      = $this->htpasswd_path;
 		$settings['wp_admin']['upgrade_ip_exclude'] = true;
 		$settings['wp_admin']['server_ip']          = '127.0.0.1';
 
@@ -966,7 +988,7 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 		$settings['ip_block']['enabled']            = true;
 		$settings['ip_block']['list']               = "1.2.3.4\n5.6.7.8/24";
 		$settings['options']['wp_login_basic_auth'] = true;
-		$settings['options']['htpasswd_path']       = '/path/.htpasswd';
+		$settings['options']['htpasswd_path']       = $this->htpasswd_path;
 		$settings['rewrite']['block_bad_query']     = true;
 		$settings['rewrite']['bad_query_list']      = 'w';
 

--- a/tests/Unit/HtaccessBuilderTest.php
+++ b/tests/Unit/HtaccessBuilderTest.php
@@ -31,7 +31,11 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 		parent::set_up();
 		$this->builder = new HSS_Htaccess_Builder();
 
-		$this->htpasswd_path = tempnam( sys_get_temp_dir(), 'htpasswd_test_' );
+		$tmp = tempnam( sys_get_temp_dir(), 'htpasswd_test_' );
+		if ( ! $tmp ) {
+			$this->fail( 'Failed to create temporary .htpasswd file.' );
+		}
+		$this->htpasswd_path = $tmp;
 		file_put_contents( $this->htpasswd_path, 'testuser:$apr1$test$hash' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 	}
 
@@ -39,7 +43,7 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	 * テスト後のクリーンアップ
 	 */
 	public function tear_down(): void {
-		if ( file_exists( $this->htpasswd_path ) ) {
+		if ( ! empty( $this->htpasswd_path ) && file_exists( $this->htpasswd_path ) ) {
 			unlink( $this->htpasswd_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 		}
 		parent::tear_down();
@@ -973,6 +977,32 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 		$result = $this->builder->build_wp_admin( $settings );
 
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * wp-admin の htpasswd_path が存在しないファイルなら空配列
+	 */
+	public function test_wp_admin_nonexistent_path_returns_empty() {
+		$settings                              = $this->get_all_off_settings();
+		$settings['wp_admin']['basic_auth']    = true;
+		$settings['wp_admin']['htpasswd_path'] = '/nonexistent/path/.htpasswd';
+
+		$result = $this->builder->build_wp_admin( $settings );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * wp-login.php の htpasswd_path が存在しないファイルなら Basic 認証が出力されない
+	 */
+	public function test_file_protection_wp_login_nonexistent_path_no_output() {
+		$settings                                   = $this->get_all_off_settings();
+		$settings['options']['wp_login_basic_auth'] = true;
+		$settings['options']['htpasswd_path']       = '/nonexistent/path/.htpasswd';
+
+		$output = $this->build_root_string( $settings );
+
+		$this->assertStringNotContainsString( 'AuthType BASIC', $output );
 	}
 
 	// =========================================================================

--- a/tests/Unit/HtaccessBuilderTest.php
+++ b/tests/Unit/HtaccessBuilderTest.php
@@ -985,7 +985,20 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_wp_admin_nonexistent_path_returns_empty() {
 		$settings                              = $this->get_all_off_settings();
 		$settings['wp_admin']['basic_auth']    = true;
-		$settings['wp_admin']['htpasswd_path'] = '/nonexistent/path/.htpasswd';
+		$settings['wp_admin']['htpasswd_path'] = sys_get_temp_dir() . '/hss_nonexistent_' . uniqid() . '.htpasswd';
+
+		$result = $this->builder->build_wp_admin( $settings );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * wp-admin の htpasswd_path がディレクトリなら空配列
+	 */
+	public function test_wp_admin_directory_path_returns_empty() {
+		$settings                              = $this->get_all_off_settings();
+		$settings['wp_admin']['basic_auth']    = true;
+		$settings['wp_admin']['htpasswd_path'] = sys_get_temp_dir();
 
 		$result = $this->builder->build_wp_admin( $settings );
 
@@ -998,7 +1011,20 @@ class HtaccessBuilderTest extends WP_UnitTestCase {
 	public function test_file_protection_wp_login_nonexistent_path_no_output() {
 		$settings                                   = $this->get_all_off_settings();
 		$settings['options']['wp_login_basic_auth'] = true;
-		$settings['options']['htpasswd_path']       = '/nonexistent/path/.htpasswd';
+		$settings['options']['htpasswd_path']       = sys_get_temp_dir() . '/hss_nonexistent_' . uniqid() . '.htpasswd';
+
+		$output = $this->build_root_string( $settings );
+
+		$this->assertStringNotContainsString( 'AuthType BASIC', $output );
+	}
+
+	/**
+	 * wp-login.php の htpasswd_path がディレクトリなら Basic 認証が出力されない
+	 */
+	public function test_file_protection_wp_login_directory_path_no_output() {
+		$settings                                   = $this->get_all_off_settings();
+		$settings['options']['wp_login_basic_auth'] = true;
+		$settings['options']['htpasswd_path']       = sys_get_temp_dir();
 
 		$output = $this->build_root_string( $settings );
 


### PR DESCRIPTION
## 概要

セキュリティ監査レポートで「改善を推奨する点」として挙げられた 3 件の軽微な改善に対応。

Closes #9

---

## 変更内容

### 推奨 1: ビューファイルの style 属性出力に `esc_attr()` を適用

ハードコード文字列で XSS リスクはないが、WordPress コーディング規約に準拠するため `esc_attr()` でエスケープ。

**対象**: 4 ファイル・11 箇所
- `admin/views/tab-ip-block.php`（1 箇所）
- `admin/views/tab-rewrite.php`（3 箇所）
- `admin/views/tab-headers.php`（4 箇所）
- `admin/views/tab-wp-admin.php`（2 箇所）

```php
// Before
style="display:none;"

// After
style="<?php echo esc_attr( 'display:none;' ); ?>"
```

### 推奨 2: `htpasswd_path` の追加バリデーション

`sanitize_text_field()` に加えて `realpath()` / `file_exists()` / `! is_dir()` の検証を追加。無効なパスの場合は該当ディレクティブを出力しない。

**対象**: `includes/class-hss-htaccess-builder.php`
- `build_wp_admin()` メソッド
- `build_file_protection_section()` メソッド

### 推奨 3: `WP_Filesystem` API への移行 → 見送り

WordPress コア自体が `.htaccess` 操作に `file_put_contents()` を使用しているため、現状維持とする。既存の `phpcs:ignore` コメントで対応済み。

---

## 検証方法

1. `composer phpcs` — エラーなし ✅
2. 管理画面から各タブの表示が正常であること
3. `.htpasswd` パスに無効な値を設定した場合に .htaccess へ出力されないこと

## 変更ファイル一覧（6 ファイル）

| ファイル | 変更内容 |
|---|---|
| `admin/views/tab-ip-block.php` | style 属性エスケープ |
| `admin/views/tab-rewrite.php` | style 属性エスケープ |
| `admin/views/tab-headers.php` | style 属性エスケープ |
| `admin/views/tab-wp-admin.php` | style 属性エスケープ |
| `includes/class-hss-htaccess-builder.php` | htpasswd_path バリデーション追加 |
| `readme.txt` | Changelog 更新 |